### PR TITLE
ugettex_lazzy -> gettext_lazzy

### DIFF
--- a/activity_log/models.py
+++ b/activity_log/models.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 
 from django.db import models
 from django.utils import timezone
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.apps import apps
 from django.dispatch import receiver
 from django.db.models.signals import pre_migrate


### PR DESCRIPTION
fix django 4.0 support
ugettext_lazzy is depricated.